### PR TITLE
Bump v0.1.3 policy version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.2
+version: 0.1.3
 name: rancher-project-quotas-namespace-validator
 displayName: Rancher Project quotas namespace validator
-createdAt: 2023-03-23T07:23:03.300702324Z
+createdAt: 2023-07-07T18:54:55.156375813Z
 description: Prevent the creation of Namespace under a Rancher Project that doesn't have any resource quota left
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/rancher-project-quotas-namespace-validator
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/rancher-project-quotas-namespace-validator:v0.1.2
+  image: ghcr.io/kubewarden/policies/rancher-project-quotas-namespace-validator:v0.1.3
 keywords:
 - rancher
 - project
 - quotas
 links:
 - name: policy
-  url: https://github.com/kubewarden/rancher-project-quotas-namespace-validator/releases/download/v0.1.2/policy.wasm
+  url: https://github.com/kubewarden/rancher-project-quotas-namespace-validator/releases/download/v0.1.3/policy.wasm
 - name: source
   url: https://github.com/kubewarden/rancher-project-quotas-namespace-validator
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/rancher-project-quotas-namespace-validator:v0.1.2
+  kwctl pull ghcr.io/kubewarden/policies/rancher-project-quotas-namespace-validator:v0.1.3
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.3 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.3

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
