### PR TITLE
ci: Fix signing step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,11 +72,9 @@ jobs:
       - name: Sign BOM file
         shell: bash
         run: |
-          cosign sign-blob --output-certificate policy-sbom.spdx.cert \
+          cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
             --output-signature policy-sbom.spdx.sig \
             policy-sbom.spdx.json
-        env:
-          COSIGN_EXPERIMENTAL: 1
       - name: Upload policy SBOM files
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:


### PR DESCRIPTION

## Description

Move to cosign v3.


<!-- Please provide the link to the GitHub issue you are addressing -->
After https://github.com/kubewarden/rancher-project-quotas-namespace-validator/pull/18, the release step seems to be broken. We forgot to move to cosign v3.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
