### PR TITLE
chore(deps): tinygo v0.39.0 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SOURCE_FILES := $(shell find . -type f -name '*.go')
 
-CONTAINER_IMAGE = "tinygo/tinygo:0.37.0"
+CONTAINER_IMAGE = "tinygo/tinygo:0.39.0"
 
 policy.wasm: $(SOURCE_FILES) go.mod go.sum
 	docker run \


### PR DESCRIPTION
## Description

To be possible to update the golang version to v1.25 it's necessary to bump the Tinygo version to v0.39.0.
